### PR TITLE
Correção links do binder

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -22,7 +22,7 @@ O workshop todo foi gravado e disponibilizado no YouTube na playlist abaixo:
 knitr::include_graphics("images/code-hero.png")
 ```
 
-**RStudio**: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/storopoli/Estatistica-Bayesiana/master?urlpath=rstudio)
+**RStudio**: [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/storopoli/Linguagem-R/main?urlpath=rstudio)
 
 Disciplina de Análise de Dados com R para alunos de pós-graduação. O conteúdo é todo baseado no universo do [`{tidyverse}`](https://www.tidyverse.org).
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Linguagem R
 </div>
 
 **RStudio**:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/storopoli/Estatistica-Bayesiana/master?urlpath=rstudio)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/storopoli/Linguagem-R/main?urlpath=rstudio)
 
 Disciplina de Análise de Dados com R para alunos de pós-graduação. O
 conteúdo é todo baseado no universo do

--- a/_footer.html
+++ b/_footer.html
@@ -1,3 +1,3 @@
-© Copyright 2021 [Jose Storopoli](https://github.com/storopoli/Estatistica-Bayesiana).
+© Copyright 2021 [Jose Storopoli](https://github.com/storopoli/Linguagem-R).
 
 Content licensed under the [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).

--- a/docs/index.html
+++ b/docs/index.html
@@ -2457,7 +2457,7 @@ Figure 1: Linguagem R
 </p>
 </div>
 </div>
-<p><strong>RStudio</strong>: <a href="https://mybinder.org/v2/gh/storopoli/Estatistica-Bayesiana/master?urlpath=rstudio"><img src="https://mybinder.org/badge_logo.svg" alt="Binder" /></a></p>
+<p><strong>RStudio</strong>: <a href="https://mybinder.org/v2/gh/storopoli/Linguagem-R/main?urlpath=rstudio"><img src="https://mybinder.org/badge_logo.svg" alt="Binder" /></a></p>
 <p>Disciplina de Análise de Dados com R para alunos de pós-graduação. O conteúdo é todo baseado no universo do <a href="https://www.tidyverse.org"><code>{tidyverse}</code></a>.</p>
 <p>Será coberto conteúdos sobre leitura, manipulação e exportação de dados com R. Recomendo o livro <strong>R para Data Science</strong> (Figura <a href="#fig:data-science-book">2</a>) que pode ser encontrado gratuitamente <a href="https://r4ds.had.co.nz">aqui</a> e possui uma <a href="https://www.amazon.com.br/Para-Data-Science-Hadley-Wickham/dp/8550803243">versão impressa em português</a>.</p>
 <div class="layout-chunk" data-layout="l-body">
@@ -2531,7 +2531,7 @@ Figure 2: R for Data Science
 <!--/radix_placeholder_appendices-->
 <!--radix_placeholder_navigation_after_body-->
 <div class="distill-site-nav distill-site-footer">
-<p>© Copyright 2021 <a href="https://github.com/storopoli/Estatistica-Bayesiana">Jose Storopoli</a>.</p>
+<p>© Copyright 2021 <a href="https://github.com/storopoli/Linguagem-R">Jose Storopoli</a>.</p>
 <p>Content licensed under the <a href="https://creativecommons.org/licenses/by-sa/4.0/">CC BY-SA 4.0</a>.</p>
 </div>
 <!--/radix_placeholder_navigation_after_body-->


### PR DESCRIPTION
Este PR arruma os links que estavam apontando para `storopoli/Estatistica-Bayesiana` por algum motivo.